### PR TITLE
Fixed warning feature

### DIFF
--- a/website/static/script.js
+++ b/website/static/script.js
@@ -50,6 +50,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (data.success) {
                     const boxQuantity = this.closest('.box-side-by-side-container').querySelector('.box-quantity');
                     boxQuantity.textContent = data.new_quantity;
+                    const warning = this.closest('.box-side-by-side-container').querySelector('.warning');
+                    const low_stock = parseInt(this.closest('.box-side-by-side-container').querySelector('.box-low-stock').textContent);
+                    if (parseInt(boxQuantity.textContent) <= low_stock)
+                    {
+                        warning.textContent = "WARNING! LOW STOCK!";
+                    }
+                    else
+                    {
+                        warning.textContent = "";
+                    }
                 } else {
                     alert(data.message);
                 }

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -698,3 +698,7 @@ th {
         margin-left: 6px;
     }
   }
+
+  .red {
+    color: red;
+  }

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -98,10 +98,6 @@
                     {% endif %}
                 </div>
 
-                {% for category, message in get_flashed_messages(with_categories=True) %}
-                <div class="alert alert-{{category}}">{{ message }}</div>
-                {% endfor %}
-
                 {% for box in boxes %}
                 <div class="box-loop">
                     <div class="box-title">
@@ -151,8 +147,14 @@
                             Link: <span class="box-link"><a href="{{ box.link }}" class = "link-color">{{ box.link }}</a></span><br>
                             {% if admin == True %}
                             Low Stock Number: <span class="box-low-stock">{{ box.low_stock }}</span><br>
-                            Barcode: <span class="box-barcode">{{ box.barcode }}</span>
-                            {% endif %}
+                            Barcode: <span class="box-barcode">{{ box.barcode }}</span><br>
+                            <div class="red">
+                                <span class="warning">
+                                {% if box.quantity <= box.low_stock %}
+                                WARNING! LOW STOCK!
+                                {% endif %}</span>
+                                {% endif %}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/website/views.py
+++ b/website/views.py
@@ -278,7 +278,6 @@ def scan_box():
         box.quantity = max(box.quantity, 0)
 
         if box.quantity <= box.low_stock:
-            flash(f'WARNING: {box.name} is low in stock!', 'warning')
             email_content = f"""
                 <p>Dear Admin,</p>
                 <p>The stock for <strong>{box.name}</strong> is running low.</p>


### PR DESCRIPTION
Removed the previous flash warning feature, and replaced it with an extra line in each box info that shows when in low stock. This should work without having to refresh the page.